### PR TITLE
fix了下shift+g的快速跳转功能

### DIFF
--- a/LazyIDA.py
+++ b/LazyIDA.py
@@ -36,7 +36,33 @@ BITS = 0
 
 history_jmp_base = []
 
+def convertToHex():
+    t0, t1, view = idaapi.twinpos_t(), idaapi.twinpos_t(), idaapi.get_current_viewer()
+    if idaapi.read_selection(view, t0, t1):
+        start, end = t0.place(view).toea(), t1.place(view).toea()
+        size = end - start
+    elif idc.get_item_size(idc.get_screen_ea()) > 1:
+        start = idc.get_screen_ea()
+        size = idc.get_item_size(start)
+        end = start + size
+    else:
+        return False
 
+    data = idc.get_bytes(start, size)
+    if isinstance(data, str):  # python2 compatibility
+        data = bytearray(data)
+    name = idc.get_name(start, idc.GN_VISIBLE)
+    if not name:
+        name = "data"
+    if data:
+        transform_data=""
+        for i in reversed(data):
+            tmp=str(hex(i)).replace("0x","")
+            if len(tmp)==1:
+                tmp="0"+tmp
+            transform_data+=tmp
+        return transform_data
+        
 def dump_bytes(addr, size):
     return idc.get_bytes(addr, size)
 
@@ -309,7 +335,7 @@ class hotkey_action_handler_t(idaapi.action_handler_t):
             # if loc != idaapi.BADADDR:
             #   print("Goto location 0x%x" % loc)
             #   idc.jumpto(loc)
-            jmper_windows(hex_cleaner(clip_text()))
+            jmper_windows(convertToHex())
         return 1
 
     def update(self, ctx):


### PR DESCRIPTION
调试老遇到指针各种指的，经常需要各种跳过去看内存，发现陈总有完善lazyida，但是使用过程中shift+g，在我这个mac ida7.6上，失效，看了下好像是这里函数还没实现好？小弟稍微改了下，使用方法就是鼠标拖中内存中对应的n个字节，shift+g自动将其填充到框中，鼠标点击jump跳转，其他机器还没测试，觉得有用感觉就pr上去了